### PR TITLE
Add admin-only user management module

### DIFF
--- a/modules/usuarios/crear.php
+++ b/modules/usuarios/crear.php
@@ -1,0 +1,63 @@
+<?php
+session_start();
+if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
+    header('Location: /public/index.php');
+    exit;
+}
+
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../includes/header.php';
+require_once __DIR__ . '/../../includes/menu.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $usuario = trim($_POST['usuario']);
+    $nombre = trim($_POST['nombre']);
+    $rol = $_POST['rol'];
+    $activo = isset($_POST['activo']) ? 1 : 0;
+    $clave = trim($_POST['clave']);
+
+    if ($usuario && $nombre && $rol && $clave) {
+        $hash = password_hash($clave, PASSWORD_BCRYPT);
+        $stmt = $pdo->prepare('INSERT INTO usuarios (usuario, clave, nombre, rol, activo) VALUES (?, ?, ?, ?, ?)');
+        $stmt->execute([$usuario, $hash, $nombre, $rol, $activo]);
+        header('Location: index.php');
+        exit;
+    }
+    $error = 'Todos los campos son obligatorios';
+}
+?>
+<h2>Nuevo Usuario</h2>
+<?php if (!empty($error)) echo '<div class="alert alert-danger">'.$error.'</div>'; ?>
+<form method="post">
+    <div class="mb-3">
+        <label class="form-label">Usuario</label>
+        <input type="text" name="usuario" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="nombre" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Rol</label>
+        <select name="rol" class="form-select">
+            <option value="vendedor">vendedor</option>
+            <option value="repositor">repositor</option>
+            <option value="compras">compras</option>
+            <option value="gerente">gerente</option>
+            <option value="admin">admin</option>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Contraseña</label>
+        <input type="password" name="clave" class="form-control" required>
+    </div>
+    <div class="form-check mb-3">
+        <input class="form-check-input" type="checkbox" name="activo" id="activo" checked>
+        <label class="form-check-label" for="activo">Activo</label>
+    </div>
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="index.php" class="btn btn-secondary">Cancelar</a>
+</form>
+<?php
+require_once __DIR__ . '/../../includes/footer.php';
+

--- a/modules/usuarios/editar.php
+++ b/modules/usuarios/editar.php
@@ -1,0 +1,67 @@
+<?php
+session_start();
+if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
+    header('Location: /public/index.php');
+    exit;
+}
+
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../includes/header.php';
+require_once __DIR__ . '/../../includes/menu.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT id, usuario, nombre, rol, activo FROM usuarios WHERE id = ?');
+$stmt->execute([$id]);
+$usuario = $stmt->fetch();
+if (!$usuario) {
+    echo '<div class="alert alert-danger">Usuario no encontrado</div>';
+    require_once __DIR__ . '/../../includes/footer.php';
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $nombre = trim($_POST['nombre']);
+    $rol = $_POST['rol'];
+    $activo = isset($_POST['activo']) ? 1 : 0;
+    if ($nombre && $rol) {
+        $stmt = $pdo->prepare('UPDATE usuarios SET nombre=?, rol=?, activo=? WHERE id=?');
+        $stmt->execute([$nombre, $rol, $activo, $id]);
+        header('Location: index.php');
+        exit;
+    }
+    $error = 'Nombre y rol son obligatorios';
+}
+?>
+<h2>Editar Usuario</h2>
+<?php if (!empty($error)) echo '<div class="alert alert-danger">'.$error.'</div>'; ?>
+<form method="post">
+    <div class="mb-3">
+        <label class="form-label">Usuario</label>
+        <input type="text" class="form-control" value="<?php echo htmlspecialchars($usuario['usuario']); ?>" disabled>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="nombre" class="form-control" value="<?php echo htmlspecialchars($usuario['nombre']); ?>" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Rol</label>
+        <select name="rol" class="form-select">
+            <?php
+            $roles = ['vendedor','repositor','compras','gerente','admin'];
+            foreach ($roles as $r) {
+                $selected = $usuario['rol'] === $r ? 'selected' : '';
+                echo "<option value='$r' $selected>$r</option>";
+            }
+            ?>
+        </select>
+    </div>
+    <div class="form-check mb-3">
+        <input class="form-check-input" type="checkbox" name="activo" id="activo" <?php echo $usuario['activo'] ? 'checked' : ''; ?>>
+        <label class="form-check-label" for="activo">Activo</label>
+    </div>
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="index.php" class="btn btn-secondary">Cancelar</a>
+</form>
+<?php
+require_once __DIR__ . '/../../includes/footer.php';
+

--- a/modules/usuarios/index.php
+++ b/modules/usuarios/index.php
@@ -1,0 +1,46 @@
+<?php
+session_start();
+if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
+    header('Location: /public/index.php');
+    exit;
+}
+
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../includes/header.php';
+require_once __DIR__ . '/../../includes/menu.php';
+
+// Obtener usuarios
+$stmt = $pdo->query('SELECT id, usuario, nombre, rol, activo FROM usuarios ORDER BY id');
+$usuarios = $stmt->fetchAll();
+?>
+<h2>Gestión de Usuarios</h2>
+<a href="crear.php" class="btn btn-primary mb-3">Nuevo Usuario</a>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Usuario</th>
+            <th>Nombre</th>
+            <th>Rol</th>
+            <th>Activo</th>
+            <th>Acciones</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($usuarios as $u): ?>
+            <tr>
+                <td><?php echo $u['id']; ?></td>
+                <td><?php echo htmlspecialchars($u['usuario']); ?></td>
+                <td><?php echo htmlspecialchars($u['nombre']); ?></td>
+                <td><?php echo $u['rol']; ?></td>
+                <td><?php echo $u['activo'] ? 'Sí' : 'No'; ?></td>
+                <td>
+                    <a class="btn btn-sm btn-secondary" href="editar.php?id=<?php echo $u['id']; ?>">Editar</a>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<?php
+require_once __DIR__ . '/../../includes/footer.php';
+


### PR DESCRIPTION
## Summary
- add a new **modules/usuarios** folder
- list users and allow creation or editing
- restrict access to admins only

## Testing
- `php -l modules/usuarios/index.php`
- `php -l modules/usuarios/crear.php`
- `php -l modules/usuarios/editar.php`


------
https://chatgpt.com/codex/tasks/task_e_687a36a5c96c832aa568331a6b3158b6