### PR TITLE
Use config paths for includes

### DIFF
--- a/auth/validar_login.php
+++ b/auth/validar_login.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
-require_once __DIR__ . '/../config/db_login.php';
+require_once __DIR__ . '/../config/config.php';
+require_once BASE_PATH . '/config/db_login.php';
 
 $usuario = trim($_POST['usuario'] ?? '');
 $clave = trim($_POST['clave'] ?? '');

--- a/modules/usuarios/crear.php
+++ b/modules/usuarios/crear.php
@@ -5,9 +5,10 @@ if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
     exit;
 }
 
-require_once __DIR__ . '/../../config/db.php';
-require_once __DIR__ . '/../../includes/header.php';
-require_once __DIR__ . '/../../includes/menu.php';
+require_once __DIR__ . '/../../config/config.php';
+require_once BASE_PATH . '/config/db.php';
+require_once INCLUDES_PATH . '/header.php';
+require_once INCLUDES_PATH . '/menu.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $usuario = trim($_POST['usuario']);
@@ -59,5 +60,5 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <a href="index.php" class="btn btn-secondary">Cancelar</a>
 </form>
 <?php
-require_once __DIR__ . '/../../includes/footer.php';
+require_once INCLUDES_PATH . '/footer.php';
 

--- a/modules/usuarios/editar.php
+++ b/modules/usuarios/editar.php
@@ -5,9 +5,10 @@ if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
     exit;
 }
 
-require_once __DIR__ . '/../../config/db.php';
-require_once __DIR__ . '/../../includes/header.php';
-require_once __DIR__ . '/../../includes/menu.php';
+require_once __DIR__ . '/../../config/config.php';
+require_once BASE_PATH . '/config/db.php';
+require_once INCLUDES_PATH . '/header.php';
+require_once INCLUDES_PATH . '/menu.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $stmt = $pdo->prepare('SELECT id, usuario, nombre, rol, activo FROM usuarios WHERE id = ?');
@@ -15,7 +16,7 @@ $stmt->execute([$id]);
 $usuario = $stmt->fetch();
 if (!$usuario) {
     echo '<div class="alert alert-danger">Usuario no encontrado</div>';
-    require_once __DIR__ . '/../../includes/footer.php';
+    require_once INCLUDES_PATH . '/footer.php';
     exit;
 }
 
@@ -63,5 +64,5 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <a href="index.php" class="btn btn-secondary">Cancelar</a>
 </form>
 <?php
-require_once __DIR__ . '/../../includes/footer.php';
+require_once INCLUDES_PATH . '/footer.php';
 

--- a/modules/usuarios/index.php
+++ b/modules/usuarios/index.php
@@ -5,9 +5,10 @@ if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
     exit;
 }
 
-require_once __DIR__ . '/../../config/db.php';
-require_once __DIR__ . '/../../includes/header.php';
-require_once __DIR__ . '/../../includes/menu.php';
+require_once __DIR__ . '/../../config/config.php';
+require_once BASE_PATH . '/config/db.php';
+require_once INCLUDES_PATH . '/header.php';
+require_once INCLUDES_PATH . '/menu.php';
 
 // Obtener usuarios
 $stmt = $pdo->query('SELECT id, usuario, nombre, rol, activo FROM usuarios ORDER BY id');
@@ -42,5 +43,5 @@ $usuarios = $stmt->fetchAll();
     </tbody>
 </table>
 <?php
-require_once __DIR__ . '/../../includes/footer.php';
+require_once INCLUDES_PATH . '/footer.php';
 

--- a/public/index.php
+++ b/public/index.php
@@ -1,19 +1,20 @@
 <?php
 session_start();
+require_once __DIR__ . '/../config/config.php';
 
 // Si el usuario NO inició sesión, mostrar login
 if (!isset($_SESSION['usuario'])) {
-    require_once __DIR__ . '/../auth/login_modal.php';
+    require_once AUTH_PATH . '/login_modal.php';
     exit;
 }
 
 // Si está logueado, incluir cabecera, menú y contenido
-require_once __DIR__ . '/../includes/header.php'; // __DIR__ es la ruta del directorio actual
-require_once __DIR__ . '/../includes/menu.php';
+require_once INCLUDES_PATH . '/header.php';
+require_once INCLUDES_PATH . '/menu.php';
 
 // Mostrar el dashboard (o podrías redirigir a otra vista si querés)
 //require_once __DIR__ . '/../modules/dashboard/index.php';
 echo "<h1>Bienvenido, " . htmlspecialchars($_SESSION['nombre']) . "</h1>";
 
-require_once __DIR__ . '/../includes/footer.php';
+require_once INCLUDES_PATH . '/footer.php';
 


### PR DESCRIPTION
## Summary
- use `config.php` constants to load includes and database files
- adjust authentication entry point accordingly

## Testing
- `php -l modules/usuarios/index.php`
- `php -l modules/usuarios/crear.php`
- `php -l modules/usuarios/editar.php`
- `php -l public/index.php`
- `php -l auth/validar_login.php`


------
https://chatgpt.com/codex/tasks/task_e_687a3e621460832aa400bf3b421e7afc