### PR TITLE
Fix product listing columns

### DIFF
--- a/modules/productos/index.php
+++ b/modules/productos/index.php
@@ -11,7 +11,9 @@ require_once INCLUDES_PATH . '/header.php';
 require_once INCLUDES_PATH . '/menu.php';
 
 // Obtener productos disponibles
-$stmt = $pdo->query('SELECT id, nombre, precio, stock FROM productos WHERE disponible = 1 ORDER BY id');
+// La estructura de la base define precio_venta, stock_actual y un campo
+// "estado" que indica si el producto está habilitado (1) o no.
+$stmt = $pdo->query('SELECT id, nombre, precio_venta, stock_actual FROM productos WHERE estado = 1 ORDER BY id');
 $productos = $stmt->fetchAll();
 ?>
 <h2>Listado de Productos</h2>
@@ -30,8 +32,8 @@ $productos = $stmt->fetchAll();
         <?php foreach ($productos as $p): ?>
             <tr>
                 <td><?php echo htmlspecialchars($p['nombre']); ?></td>
-                <td><?php echo number_format($p['precio'], 2); ?></td>
-                <td><?php echo $p['stock']; ?></td>
+                <td><?php echo number_format($p['precio_venta'], 2); ?></td>
+                <td><?php echo $p['stock_actual']; ?></td>
                 <td>
                     <a class="btn btn-sm btn-secondary" href="editar.php?id=<?php echo $p['id']; ?>">Editar</a>
                     <a class="btn btn-sm btn-warning" href="descontinuar.php?id=<?php echo $p['id']; ?>">Descontinuar</a>


### PR DESCRIPTION
## Summary
- query for product listing from new columns in DB
- print `precio_venta` and `stock_actual` instead of outdated columns

## Testing
- `php -l modules/productos/index.php`


------
https://chatgpt.com/codex/tasks/task_e_687e0fa16c2c832a8184c10a0470ea1d