### PR TITLE
Add products link in menu

### DIFF
--- a/includes/menu.php
+++ b/includes/menu.php
@@ -18,6 +18,12 @@
             </li>
         <?php endif; ?>
 
+        <?php if ($_SESSION['rol'] === 'admin'): ?>
+            <li class="nav-item">
+            <a class="nav-link" href="<?php echo BASE_URL . 'modules/productos/'; ?>">Productos</a>
+            </li>
+        <?php endif; ?>
+
         <?php if (in_array($_SESSION['rol'], ['admin'])): ?>
             <li class="nav-item">
             <a class="nav-link" href="<?php echo BASE_URL . 'modules/usuarios/index.php'; ?>">Usuarios</a>


### PR DESCRIPTION
## Summary
- add a menu entry for `Productos`

## Testing
- `php -l includes/menu.php`
- `php -l modules/productos/index.php`


------
https://chatgpt.com/codex/tasks/task_e_687ffd318dd8832a804236898d16ee33