### PR TITLE
Use BASE_PATH for AFIP config

### DIFF
--- a/afip/cert/afip_config.php
+++ b/afip/cert/afip_config.php
@@ -4,12 +4,13 @@
 // usando la librería oficial de AFIP para PHP
 // y el usuario de prueba 20111111112
 
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../../config/config.php';
+require_once VENDOR_PATH . '/autoload.php';
 
 $afip = new Afip([
     'CUIT' => 20111111112,
     'production' => false,
-    'cert' => __DIR__ . '/cert/certificate.crt',
-    'key'  => __DIR__ . '/cert/private.key',
-    'ta_folder' => __DIR__ . '/tmp' // opcional para almacenar el ticket de acceso
+    'cert' => AFIP_CERT_PATH . '/certificate.crt',
+    'key'  => AFIP_CERT_PATH . '/private.key',
+    'ta_folder' => AFIP_CERT_PATH . '/tmp' // opcional para almacenar el ticket de acceso
 ]);

--- a/config/config.php
+++ b/config/config.php
@@ -8,3 +8,7 @@ define('PUBLIC_PATH', BASE_PATH . '/public');
 define('MODULES_PATH', BASE_PATH . '/modules');
 define('AUTH_PATH', BASE_PATH . '/auth');
 
+// Rutas adicionales para dependencias externas y certificados de AFIP
+define('VENDOR_PATH', BASE_PATH . '/vendor');
+define('AFIP_CERT_PATH', BASE_PATH . '/afip/cert');
+


### PR DESCRIPTION
## Summary
- create constants for vendor and AFIP certificate paths
- load config in AFIP setup and use new constants

## Testing
- `php -l afip/cert/afip_config.php`
- `php -l config/config.php`


------
https://chatgpt.com/codex/tasks/task_e_6880cb0dea54832a9de4eca108fc3c95