### PR TITLE
Add clients link to menu

### DIFF
--- a/includes/menu.php
+++ b/includes/menu.php
@@ -24,6 +24,12 @@
             </li>
         <?php endif; ?>
 
+        <?php if ($_SESSION['rol'] === 'admin'): ?>
+            <li class="nav-item">
+            <a class="nav-link" href="<?php echo BASE_URL . 'modules/clientes/'; ?>">Clientes</a>
+            </li>
+        <?php endif; ?>
+
         <?php if (in_array($_SESSION['rol'], ['admin'])): ?>
             <li class="nav-item">
             <a class="nav-link" href="<?php echo BASE_URL . 'modules/usuarios/index.php'; ?>">Usuarios</a>


### PR DESCRIPTION
## Summary
- show **Clientes** section for administrators in the menu

## Testing
- `php -l includes/menu.php`
- `php -l modules/clientes/index.php`


------
https://chatgpt.com/codex/tasks/task_e_688206837718832a92e5300d6f3fd15f