### PR TITLE
Add CUIT/CUIL validation for client forms

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,19 @@
+<?php
+function validarCuit($cuit) {
+    if (!preg_match('/^\d{11}$/', $cuit)) {
+        return false;
+    }
+    $weights = [5,4,3,2,7,6,5,4,3,2];
+    $sum = 0;
+    for ($i = 0; $i < 10; $i++) {
+        $sum += $cuit[$i] * $weights[$i];
+    }
+    $mod = 11 - ($sum % 11);
+    if ($mod == 11) {
+        $mod = 0;
+    } elseif ($mod == 10) {
+        $mod = 9;
+    }
+    return $mod == $cuit[10];
+}
+


### PR DESCRIPTION
## Summary
- validate CUIT/CUIL on the server using `validarCuit`
- add JS validation for CUIT/CUIL on create/edit forms

## Testing
- `php -l includes/functions.php`
- `php -l modules/clientes/crear.php`
- `php -l modules/clientes/editar.php`


------
https://chatgpt.com/codex/tasks/task_e_688215d6e3c4832a842b1ab6e129ff44