### PR TITLE
Refactor login flow and fix redirects

### DIFF
--- a/auth/validar_login.php
+++ b/auth/validar_login.php
@@ -7,7 +7,7 @@ $usuario = trim($_POST['usuario'] ?? '');
 $clave = trim($_POST['clave'] ?? '');
 
 if ($usuario === '' || $clave === '') {
-    header('Location: ' . BASE_URL . 'index.php?error=1');
+    header('Location: ' . BASE_URL . 'login.php?error=1');
     exit;
 }
 
@@ -23,7 +23,7 @@ try {
         $_SESSION['rol'] = $user['rol'];
         header('Location: ' . BASE_URL . 'index.php');
     } else {
-        header('Location: ' . BASE_URL . 'index.php?error=1');
+        header('Location: ' . BASE_URL . 'login.php?error=1');
     }
 } catch (PDOException $e) {
     die("Error: " . $e->getMessage());

--- a/public/index.php
+++ b/public/index.php
@@ -2,9 +2,9 @@
 session_start();
 require_once __DIR__ . '/../config/config.php';
 
-// Si el usuario NO inició sesión, mostrar login
+// Si el usuario NO inició sesión, redirigir al login
 if (!isset($_SESSION['usuario'])) {
-    require_once AUTH_PATH . '/login_modal.php';
+    header('Location: ' . BASE_URL . 'login.php');
     exit;
 }
 

--- a/public/login.php
+++ b/public/login.php
@@ -1,2 +1,18 @@
 <?php
-require_once __DIR__ . '/../auth/validar_login.php';
+session_start();
+require_once __DIR__ . '/../config/config.php';
+
+// Si ya está logueado, redirigir al inicio
+if (isset($_SESSION['usuario'])) {
+    header('Location: ' . BASE_URL . 'index.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    require_once AUTH_PATH . '/validar_login.php';
+    exit;
+}
+
+// Mostrar formulario de login
+require_once AUTH_PATH . '/login_modal.php';
+


### PR DESCRIPTION
## Summary
- Redirect unauthenticated users from the index to the login page
- Centralize login flow to handle form display and validation
- Send failed logins back to the login page with an error flag

## Testing
- `php -l public/index.php`
- `php -l public/login.php`
- `php -l auth/validar_login.php`


------
https://chatgpt.com/codex/tasks/task_e_688f5595ae98832ab0a7d06b6e82312e