### PR TITLE
Fix URL routing and redirects

### DIFF
--- a/auth/login_modal.php
+++ b/auth/login_modal.php
@@ -9,7 +9,7 @@
 <body class="bg-light d-flex justify-content-center align-items-center" style="height: 100vh;">
     <div class="card shadow p-4" style="min-width: 300px;">
         <h4 class="mb-3">Inicio de Sesión</h4>
-        <form action="<?php echo PUBLIC_PATH . 'login.php'; ?>" method="POST">
+        <form action="<?php echo BASE_URL . 'login.php'; ?>" method="POST">
             <div class="mb-3">
                 <label for="usuario" class="form-label">Usuario</label>
                 <input type="text" class="form-control" id="usuario" name="usuario" required>

--- a/auth/logout.php
+++ b/auth/logout.php
@@ -2,5 +2,5 @@
 session_start();
 session_destroy();
 require_once __DIR__ . '/../config/config.php';
-header('Location: ' . PUBLIC_PATH . 'index.php');
+header('Location: ' . BASE_URL . 'index.php');
 exit;

--- a/auth/validar_login.php
+++ b/auth/validar_login.php
@@ -7,7 +7,7 @@ $usuario = trim($_POST['usuario'] ?? '');
 $clave = trim($_POST['clave'] ?? '');
 
 if ($usuario === '' || $clave === '') {
-    header('Location: ' . PUBLIC_PATH . 'index.php?error=1');
+    header('Location: ' . BASE_URL . 'index.php?error=1');
     exit;
 }
 
@@ -21,9 +21,9 @@ try {
         $_SESSION['usuario'] = $user['usuario'];
         $_SESSION['nombre'] = $user['nombre'];
         $_SESSION['rol'] = $user['rol'];
-        header('Location: ' . PUBLIC_PATH . 'index.php');
+        header('Location: ' . BASE_URL . 'index.php');
     } else {
-        header('Location: ' . PUBLIC_PATH . 'index.php?error=1');
+        header('Location: ' . BASE_URL . 'index.php?error=1');
     }
 } catch (PDOException $e) {
     die("Error: " . $e->getMessage());

--- a/config/config.php
+++ b/config/config.php
@@ -1,12 +1,17 @@
 <?php
 // __DIR__ en este contexto es /minidespensa/config
-define('BASE_PATH',__DIR__ . '/../'); // sube a /minidespensa
-define('BASE_URL', 'http://sitio1.com/public/');
+// Normalizamos la ruta base sin la barra final
+define('BASE_PATH', realpath(__DIR__ . '/..'));
 
-define('INCLUDES_PATH', BASE_PATH . '/includes'); //se 
-define('PUBLIC_PATH', BASE_PATH . '/public');//se usa para redirecciones
-define('MODULES_PATH', BASE_PATH . '/modules');//se usa para cargar modulos
-define('AUTH_PATH', BASE_PATH . '/auth');//se usa para cargar modulos de autenticacion
+// URL base del dominio y carpeta public para recursos web
+define('BASE_HOST', 'http://sitio1.com');
+define('BASE_URL', BASE_HOST . '/public/');
+
+// Rutas internas del proyecto
+define('INCLUDES_PATH', BASE_PATH . '/includes');
+define('PUBLIC_PATH', BASE_PATH . '/public'); // se usa para archivos públicos
+define('MODULES_PATH', BASE_PATH . '/modules'); // se usa para cargar módulos
+define('AUTH_PATH', BASE_PATH . '/auth'); // módulos de autenticación
 
 // Rutas adicionales para dependencias externas y certificados de AFIP
 define('VENDOR_PATH', BASE_PATH . '/vendor');

--- a/includes/menu.php
+++ b/includes/menu.php
@@ -2,42 +2,42 @@
     <ul class="nav nav-pills">
         <?php if (in_array($_SESSION['rol'], ['admin', 'gerente'])): ?>
             <li class="nav-item">
-            <a class="nav-link" href="<?php echo BASE_URL . '../modules/dashboard/'; ?>">Dashboard</a>
+            <a class="nav-link" href="<?php echo BASE_HOST . '/modules/dashboard/'; ?>">Dashboard</a>
             </li>
         <?php endif; ?>
 
         <?php if (in_array($_SESSION['rol'], ['admin', 'compras'])): ?>
             <li class="nav-item">
-            <a class="nav-link" href="<?php echo BASE_URL . '../modules/compras/'; ?>">Compras</a>
+            <a class="nav-link" href="<?php echo BASE_HOST . '/modules/compras/'; ?>">Compras</a>
             </li>
         <?php endif; ?>
 
         <?php if (in_array($_SESSION['rol'], ['admin', 'vendedor'])): ?>
             <li class="nav-item">
-            <a class="nav-link" href="<?php echo BASE_URL . '../modules/ventas/'; ?>">Facturación</a>
+            <a class="nav-link" href="<?php echo BASE_HOST . '/modules/ventas/'; ?>">Facturación</a>
             </li>
         <?php endif; ?>
 
         <?php if ($_SESSION['rol'] === 'admin'): ?>
             <li class="nav-item">
-            <a class="nav-link" href="<?php echo BASE_URL . '../modules/productos/'; ?>">Productos</a>
+            <a class="nav-link" href="<?php echo BASE_HOST . '/modules/productos/'; ?>">Productos</a>
             </li>
         <?php endif; ?>
 
         <?php if ($_SESSION['rol'] === 'admin'): ?>
             <li class="nav-item">
-            <a class="nav-link" href="<?php echo BASE_URL . '../modules/clientes/'; ?>">Clientes</a>
+            <a class="nav-link" href="<?php echo BASE_HOST . '/modules/clientes/'; ?>">Clientes</a>
             </li>
         <?php endif; ?>
 
         <?php if (in_array($_SESSION['rol'], ['admin'])): ?>
             <li class="nav-item">
-            <a class="nav-link" href="<?php echo BASE_URL . '../modules/usuarios/index.php'; ?>">Usuarios</a>
+            <a class="nav-link" href="<?php echo BASE_HOST . '/modules/usuarios/'; ?>">Usuarios</a>
             </li>
         <?php endif; ?>
 
         <li class="nav-item">
-    <a class="nav-link text-danger" href="<?php echo BASE_URL . '../auth/logout.php'; ?>">Salir</a>
+    <a class="nav-link text-danger" href="<?php echo BASE_HOST . '/auth/logout.php'; ?>">Salir</a>
         </li>
     </ul>
 </div>

--- a/modules/clientes/crear.php
+++ b/modules/clientes/crear.php
@@ -1,11 +1,11 @@
 <?php
 session_start();
+require_once __DIR__ . '/../../config/config.php';
 if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
     header('Location: ' . BASE_URL . 'index.php');
     exit;
 }
 
-require_once __DIR__ . '/../../config/config.php';
 require_once BASE_PATH . '/config/db.php';
 require_once INCLUDES_PATH . '/header.php';
 require_once INCLUDES_PATH . '/menu.php';

--- a/modules/clientes/editar.php
+++ b/modules/clientes/editar.php
@@ -1,11 +1,11 @@
 <?php
 session_start();
+require_once __DIR__ . '/../../config/config.php';
 if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
     header('Location: ' . BASE_URL . 'index.php');
     exit;
 }
 
-require_once __DIR__ . '/../../config/config.php';
 require_once BASE_PATH . '/config/db.php';
 require_once INCLUDES_PATH . '/header.php';
 require_once INCLUDES_PATH . '/menu.php';

--- a/modules/clientes/index.php
+++ b/modules/clientes/index.php
@@ -1,11 +1,11 @@
 <?php
 session_start();
+require_once __DIR__ . '/../../config/config.php';
 if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
     header('Location: ' . BASE_URL . 'index.php');
     exit;
 }
 
-require_once __DIR__ . '/../../config/config.php';
 require_once BASE_PATH . '/config/db.php';
 require_once INCLUDES_PATH . '/header.php';
 require_once INCLUDES_PATH . '/menu.php';

--- a/modules/productos/crear.php
+++ b/modules/productos/crear.php
@@ -1,11 +1,11 @@
 <?php
 session_start();
+require_once __DIR__ . '/../../config/config.php';
 if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
     header('Location: ' . BASE_URL . 'index.php');
     exit;
 }
 
-require_once __DIR__ . '/../../config/config.php';
 require_once BASE_PATH . '/config/db.php';
 require_once INCLUDES_PATH . '/header.php';
 require_once INCLUDES_PATH . '/menu.php';

--- a/modules/productos/descontinuar.php
+++ b/modules/productos/descontinuar.php
@@ -1,11 +1,11 @@
 <?php
 session_start();
+require_once __DIR__ . '/../../config/config.php';
 if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
     header('Location: ' . BASE_URL . 'index.php');
     exit;
 }
 
-require_once __DIR__ . '/../../config/config.php';
 require_once BASE_PATH . '/config/db.php';
 require_once INCLUDES_PATH . '/header.php';
 require_once INCLUDES_PATH . '/menu.php';

--- a/modules/productos/editar.php
+++ b/modules/productos/editar.php
@@ -1,11 +1,11 @@
 <?php
 session_start();
+require_once __DIR__ . '/../../config/config.php';
 if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
     header('Location: ' . BASE_URL . 'index.php');
     exit;
 }
 
-require_once __DIR__ . '/../../config/config.php';
 require_once BASE_PATH . '/config/db.php';
 require_once INCLUDES_PATH . '/header.php';
 require_once INCLUDES_PATH . '/menu.php';

--- a/modules/productos/index.php
+++ b/modules/productos/index.php
@@ -1,11 +1,11 @@
 <?php
 session_start();
+require_once __DIR__ . '/../../config/config.php';
 if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
     header('Location: ' . BASE_URL . 'index.php');
     exit;
 }
 
-require_once __DIR__ . '/../../config/config.php';
 require_once BASE_PATH . '/config/db.php';
 require_once INCLUDES_PATH . '/header.php';
 require_once INCLUDES_PATH . '/menu.php';

--- a/modules/usuarios/crear.php
+++ b/modules/usuarios/crear.php
@@ -1,11 +1,11 @@
 <?php
 session_start();
+require_once __DIR__ . '/../../config/config.php';
 if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
     header('Location: ' . BASE_URL . 'index.php');
     exit;
 }
 
-require_once __DIR__ . '/../../config/config.php';
 require_once BASE_PATH . '/config/db.php';
 require_once INCLUDES_PATH . '/header.php';
 require_once INCLUDES_PATH . '/menu.php';

--- a/modules/usuarios/editar.php
+++ b/modules/usuarios/editar.php
@@ -1,11 +1,11 @@
 <?php
 session_start();
+require_once __DIR__ . '/../../config/config.php';
 if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
     header('Location: ' . BASE_URL . 'index.php');
     exit;
 }
 
-require_once __DIR__ . '/../../config/config.php';
 require_once BASE_PATH . '/config/db.php';
 require_once INCLUDES_PATH . '/header.php';
 require_once INCLUDES_PATH . '/menu.php';

--- a/modules/usuarios/index.php
+++ b/modules/usuarios/index.php
@@ -1,11 +1,11 @@
 <?php
 session_start();
+require_once __DIR__ . '/../../config/config.php';
 if (!isset($_SESSION['usuario']) || $_SESSION['rol'] !== 'admin') {
     header('Location: ' . BASE_URL . 'index.php');
     exit;
 }
 
-require_once __DIR__ . '/../../config/config.php';
 require_once BASE_PATH . '/config/db.php';
 require_once INCLUDES_PATH . '/header.php';
 require_once INCLUDES_PATH . '/menu.php';

--- a/modules/ventas/index.php
+++ b/modules/ventas/index.php
@@ -1,11 +1,11 @@
 <?php
 session_start();
+require_once __DIR__ . '/../../config/config.php';
 if (!isset($_SESSION['usuario']) || !in_array($_SESSION['rol'], ['admin', 'vendedor'])) {
     header('Location: ' . BASE_URL . 'index.php');
     exit;
 }
 
-require_once __DIR__ . '/../../config/config.php';
 require_once BASE_PATH . '/config/db.php';
 require_once INCLUDES_PATH . '/header.php';
 require_once INCLUDES_PATH . '/menu.php';

--- a/modules/ventas/ventas.php
+++ b/modules/ventas/ventas.php
@@ -1,11 +1,11 @@
 <?php
 session_start();
+require_once __DIR__ . '/../../config/config.php';
 if (!isset($_SESSION['usuario']) || !in_array($_SESSION['rol'], ['admin', 'vendedor'])) {
     header('Location: ' . BASE_URL . 'index.php');
     exit;
 }
 
-require_once __DIR__ . '/../../config/config.php';
 require_once BASE_PATH . '/config/db.php';
 require_once INCLUDES_PATH . '/header.php';
 require_once INCLUDES_PATH . '/menu.php';


### PR DESCRIPTION
## Summary
- Normalize base path definition and add BASE_HOST/BASE_URL constants for clearer routing
- Replace filesystem paths in redirects with proper BASE_URL links
- Load configuration before permission checks and use absolute URLs in navigation

## Testing
- `php -l auth/login_modal.php auth/logout.php auth/validar_login.php config/config.php includes/menu.php modules/clientes/crear.php modules/clientes/editar.php modules/clientes/index.php modules/productos/crear.php modules/productos/descontinuar.php modules/productos/editar.php modules/productos/index.php modules/usuarios/crear.php modules/usuarios/editar.php modules/usuarios/index.php modules/ventas/index.php modules/ventas/ventas.php`


------
https://chatgpt.com/codex/tasks/task_e_6890848c2570832aa56d057b97c3873f