### PR TITLE
Corrige rutas de navegación en el menú

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -7,7 +7,7 @@
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark px-3">
-    <a class="navbar-brand" href="<?php echo BASE_URL . 'index.php'; ?>">MiniDespensa</a>
+    <a class="navbar-brand" href="<?php echo BASE_URL . '/index.php'; ?>">MiniDespensa</a>
     <div class="ms-auto text-white">
         <?php echo $_SESSION['nombre']; ?> (<?php echo $_SESSION['rol']; ?>)
     </div>

--- a/includes/menu.php
+++ b/includes/menu.php
@@ -2,42 +2,42 @@
     <ul class="nav nav-pills">
         <?php if (in_array($_SESSION['rol'], ['admin', 'gerente'])): ?>
             <li class="nav-item">
-            <a class="nav-link" href="<?php echo require_once BASE_URL . '/dashboard/'; ?>">Dashboard</a>
+                <a class="nav-link" href="<?php echo BASE_URL . '/dashboard/'; ?>">Dashboard</a>
             </li>
         <?php endif; ?>
 
         <?php if (in_array($_SESSION['rol'], ['admin', 'compras'])): ?>
             <li class="nav-item">
-            <a class="nav-link" href="<?php echo require_once BASE_URL . '/compras/'; ?>">Compras</a>
+                <a class="nav-link" href="<?php echo BASE_URL . '/compras/'; ?>">Compras</a>
             </li>
         <?php endif; ?>
 
         <?php if (in_array($_SESSION['rol'], ['admin', 'vendedor'])): ?>
             <li class="nav-item">
-            <a class="nav-link" href="<?php echo require_once BASE_URL . '/ventas/'; ?>">Facturación</a>
+                <a class="nav-link" href="<?php echo BASE_URL . '/ventas/'; ?>">Facturación</a>
             </li>
         <?php endif; ?>
 
         <?php if ($_SESSION['rol'] === 'admin'): ?>
             <li class="nav-item">
-            <a class="nav-link" href="<?php echo require_once BASE_URL . '/productos/'; ?>">Productos</a>
+                <a class="nav-link" href="<?php echo BASE_URL . '/productos/'; ?>">Productos</a>
             </li>
         <?php endif; ?>
 
         <?php if ($_SESSION['rol'] === 'admin'): ?>
             <li class="nav-item">
-            <a class="nav-link" href="<?php echo require_once BASE_URL . '/clientes/'; ?>">Clientes</a>
+                <a class="nav-link" href="<?php echo BASE_URL . '/clientes/'; ?>">Clientes</a>
             </li>
         <?php endif; ?>
 
         <?php if (in_array($_SESSION['rol'], ['admin'])): ?>
             <li class="nav-item">
-            <a class="nav-link" href="<?php echo require_once BASE_URL . '/usuarios/'; ?>">Usuarios</a>
+                <a class="nav-link" href="<?php echo BASE_URL . '/usuarios/'; ?>">Usuarios</a>
             </li>
         <?php endif; ?>
 
         <li class="nav-item">
-    <a class="nav-link text-danger" href="<?php echo require_once AUTH_URL . '/logout.php'; ?>">Salir</a>
+            <a class="nav-link text-danger" href="<?php echo AUTH_URL . '/logout.php'; ?>">Salir</a>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
## Summary
- Reemplaza `require_once` en los enlaces del menú por URLs generadas con `BASE_URL` y `AUTH_URL`.
- Ajusta el enlace de la cabecera para apuntar correctamente a `/index.php`.

## Testing
- `php -l includes/menu.php`
- `php -l includes/header.php`
- `php public/index.php`

------
https://chatgpt.com/codex/tasks/task_e_68913b4dd6ac832abdbaa4074d67a070