### PR TITLE
Normalize base URL and update links

### DIFF
--- a/auth/login_modal.php
+++ b/auth/login_modal.php
@@ -9,7 +9,7 @@
 <body class="bg-light d-flex justify-content-center align-items-center" style="height: 100vh;">
     <div class="card shadow p-4" style="min-width: 300px;">
         <h4 class="mb-3">Inicio de Sesión</h4>
-        <form action="<?php echo BASE_URL . '/login.php'; ?>" method="POST">
+        <form action="<?php echo BASE_URL . 'login.php'; ?>" method="POST">
             <div class="mb-3">
                 <label for="usuario" class="form-label">Usuario</label>
                 <input type="text" class="form-control" id="usuario" name="usuario" required>

--- a/auth/logout.php
+++ b/auth/logout.php
@@ -2,5 +2,6 @@
 session_start();
 session_destroy();
 require_once __DIR__ . '/../config/config.php';
-header('Location: ' . BASE_URL . '/index.php');
+header('Location: ' . BASE_URL . 'index.php');
 exit;
+

--- a/auth/validar_login.php
+++ b/auth/validar_login.php
@@ -7,7 +7,7 @@ $usuario = trim($_POST['usuario'] ?? '');
 $clave = trim($_POST['clave'] ?? '');
 
 if ($usuario === '' || $clave === '') {
-    header('Location: ' . BASE_HOST . '/index.php?error=1');
+    header('Location: ' . BASE_HOST . 'index.php?error=1');
     exit;
 }
 
@@ -21,11 +21,12 @@ try {
         $_SESSION['usuario'] = $user['usuario'];
         $_SESSION['nombre'] = $user['nombre'];
         $_SESSION['rol'] = $user['rol'];
-        header('Location: ' . BASE_HOST . '/index.php');
+        header('Location: ' . BASE_HOST . 'index.php');
     } else {
-        header('Location: ' . BASE_HOST . '/index.php?error=1');
+        header('Location: ' . BASE_HOST . 'index.php?error=1');
     }
 } catch (PDOException $e) {
-    die("Error: " . $e->getMessage());
+die("Error: " . $e->getMessage());
 }
 ?>
+

--- a/config/config.php
+++ b/config/config.php
@@ -3,7 +3,7 @@
 define('BASE_PATH', realpath(__DIR__ . '/..'));
 
 // URL base del dominio (DocumentRoot apunta a /public)
-define('BASE_HOST', 'http://sitio1.com');
+define('BASE_HOST', 'http://sitio1.com/');
 define('BASE_URL', BASE_HOST); // No agregues /public
 
 // Rutas internas para inclusión (NO usar en href)
@@ -13,8 +13,8 @@ define('AUTH_PATH', BASE_PATH . '/auth');
 define('PUBLIC_PATH', BASE_PATH . '/public');
 
 // Rutas web para los archivos públicos (usar en href)
-define('INCLUDES_URL', BASE_URL . '/includes'); // solo si /public/includes existe
-define('AUTH_URL', BASE_URL . '/auth');         // solo si /public/auth existe
+define('INCLUDES_URL', BASE_URL . 'includes'); // solo si /public/includes existe
+define('AUTH_URL', BASE_URL . 'auth');         // solo si /public/auth existe
 
 // Rutas adicionales para dependencias externas y certificados de AFIP
 define('VENDOR_PATH', BASE_PATH . '/vendor');

--- a/includes/header.php
+++ b/includes/header.php
@@ -7,9 +7,10 @@
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark px-3">
-    <a class="navbar-brand" href="<?php echo BASE_URL . '/index.php'; ?>">MiniDespensa</a>
+    <a class="navbar-brand" href="<?php echo BASE_URL . 'index.php'; ?>">MiniDespensa</a>
     <div class="ms-auto text-white">
         <?php echo $_SESSION['nombre']; ?> (<?php echo $_SESSION['rol']; ?>)
     </div>
 </nav>
 <div class="container my-4">
+

--- a/includes/menu.php
+++ b/includes/menu.php
@@ -2,37 +2,37 @@
     <ul class="nav nav-pills">
         <?php if (in_array($_SESSION['rol'], ['admin', 'gerente'])): ?>
             <li class="nav-item">
-                <a class="nav-link" href="<?php echo BASE_URL . '/dashboard/'; ?>">Dashboard</a>
+                <a class="nav-link" href="<?php echo BASE_URL . 'dashboard/'; ?>">Dashboard</a>
             </li>
         <?php endif; ?>
 
         <?php if (in_array($_SESSION['rol'], ['admin', 'compras'])): ?>
             <li class="nav-item">
-                <a class="nav-link" href="<?php echo BASE_URL . '/compras/'; ?>">Compras</a>
+                <a class="nav-link" href="<?php echo BASE_URL . 'compras/'; ?>">Compras</a>
             </li>
         <?php endif; ?>
 
         <?php if (in_array($_SESSION['rol'], ['admin', 'vendedor'])): ?>
             <li class="nav-item">
-                <a class="nav-link" href="<?php echo BASE_URL . '/ventas/'; ?>">Facturación</a>
+                <a class="nav-link" href="<?php echo BASE_URL . 'ventas/'; ?>">Facturación</a>
             </li>
         <?php endif; ?>
 
         <?php if ($_SESSION['rol'] === 'admin'): ?>
             <li class="nav-item">
-                <a class="nav-link" href="<?php echo BASE_URL . '/productos/'; ?>">Productos</a>
+                <a class="nav-link" href="<?php echo BASE_URL . 'productos/'; ?>">Productos</a>
             </li>
         <?php endif; ?>
 
         <?php if ($_SESSION['rol'] === 'admin'): ?>
             <li class="nav-item">
-                <a class="nav-link" href="<?php echo BASE_URL . '/clientes/'; ?>">Clientes</a>
+                <a class="nav-link" href="<?php echo BASE_URL . 'clientes/'; ?>">Clientes</a>
             </li>
         <?php endif; ?>
 
         <?php if (in_array($_SESSION['rol'], ['admin'])): ?>
             <li class="nav-item">
-                <a class="nav-link" href="<?php echo BASE_URL . '/usuarios/'; ?>">Usuarios</a>
+                <a class="nav-link" href="<?php echo BASE_URL . 'usuarios/'; ?>">Usuarios</a>
             </li>
         <?php endif; ?>
 
@@ -41,3 +41,4 @@
         </li>
     </ul>
 </div>
+


### PR DESCRIPTION
## Summary
- Append trailing slash to `BASE_HOST` and adjust related URLs
- Remove leading slashes when concatenating paths with `BASE_URL`
- Clean up authentication and navigation links to match new base URL

## Testing
- `php -l config/config.php auth/login_modal.php auth/logout.php auth/validar_login.php includes/header.php includes/menu.php`


------
https://chatgpt.com/codex/tasks/task_e_689714a5a46c832a9446e4484ac50300